### PR TITLE
Human Readable Errors, Style Cleanup, and Refetching Data after successful transactions

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -477,7 +477,7 @@ const Home: NextPage = () => {
   return (
     <div>
       <div style={{ display: 'flex', justifyContent: 'space-between', padding: 12 }}>
-        <h4 style={{ justifyContent: 'flex',  }}>(Experimental) FIAT UI</h4>
+        <h4 style={{ justifyContent: 'flex',  }}>(Experimental) FIAT I UI</h4>
         <div style={{ display: 'flex'}}>
           <ProxyButton
             {...contextData}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -265,7 +265,6 @@ export const buyCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC1155:FC': {
       if (!properties.fcData) return console.error('Missing FC data');
@@ -292,7 +291,6 @@ export const buyCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC20:FY': {
       if (!properties.fyData) return console.error('Missing FY data');
@@ -316,7 +314,6 @@ export const buyCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC20:SPT': {
       if (!properties.sptData) return console.error('Missing SPT data');
@@ -342,7 +339,6 @@ export const buyCollateralAndModifyDebt = async (
       );
       console.log(response)
       return response;
-      break;
     }
     default: {
       console.error('Unsupported vault: ', properties.vaultType);
@@ -400,7 +396,6 @@ export const sellCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
 
     case 'ERC1155:FC': {
@@ -426,7 +421,6 @@ export const sellCollateralAndModifyDebt = async (
       );
       console.log(response)
       return response;
-      break;
     }
     case 'ERC20:FY': {
       if (!properties.fyData) return console.error('Missing FY data');
@@ -450,7 +444,6 @@ export const sellCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC20:SPT': {
       if (!properties.sptData) return console.error('Missing SPT data');
@@ -477,7 +470,6 @@ export const sellCollateralAndModifyDebt = async (
       );
       console.log(response);
       return response;
-      break;
     }
     default: {
       console.error('Unsupported vault: ', properties.vaultType);
@@ -521,7 +513,6 @@ export const redeemCollateralAndModifyDebt = async (contextData: any,
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC1155:FC': {
       if (!properties.fcData) return console.error('Missing FC data');
@@ -541,7 +532,6 @@ export const redeemCollateralAndModifyDebt = async (contextData: any,
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC20:FY': {
       if (!properties.fyData) return console.error('Missing FY data');
@@ -560,7 +550,6 @@ export const redeemCollateralAndModifyDebt = async (contextData: any,
       );
       console.log(response);
       return response;
-      break;
     }
     case 'ERC20:SPT': {
       if (!properties.sptData) return console.error('Missing SPT data');
@@ -586,7 +575,6 @@ export const redeemCollateralAndModifyDebt = async (contextData: any,
       );
       console.log(response);
       return response;
-      break;
     }
     default: {
       console.error('Unsupported vault: ', properties.vaultType);

--- a/src/components/CollateralTypesTable.tsx
+++ b/src/components/CollateralTypesTable.tsx
@@ -48,7 +48,7 @@ export const CollateralTypesTable = (props: CollateralTypesTableProps) => {
       >
         <Table.Header>
           <Table.Column>Asset</Table.Column>
-          <Table.Column>APY (Yield At Maturity)</Table.Column>
+          <Table.Column>Fixed APY (Yield At Maturity)</Table.Column>
           <Table.Column>Borrow Rate (Due At Maturity)</Table.Column>
           <Table.Column>Total Assets</Table.Column>
           <Table.Column allowsSorting>Maturity (Days Until Maturity)</Table.Column>

--- a/src/components/CreatePositionModal.tsx
+++ b/src/components/CreatePositionModal.tsx
@@ -218,9 +218,9 @@ const CreatePositionModalBody = (props: CreatePositionModalProps) => {
         >
           Targeted health factor ({Number(wadToDec(formDataStore.targetedHealthFactor))})
         </Text>
-        <Card variant='bordered' borderWeight='light'>
+        <Card variant='bordered' borderWeight='light' style={{height:'100%'}}>
           <Card.Body
-            style={{ paddingLeft: '2.25rem', paddingRight: '2.25rem' }}
+            style={{ paddingLeft: '2.25rem', paddingRight: '2.25rem', overflow: 'hidden' }}
           >
             <Slider
               handleStyle={{ borderColor: '#0072F5' }}

--- a/src/components/ModifyPositionModal.tsx
+++ b/src/components/ModifyPositionModal.tsx
@@ -142,7 +142,6 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 <Navbar.Link
                   isActive={formDataStore.mode === 'deposit'}
                   onClick={() => {
-                    formDataStore.reset();
                     formDataStore.setMode('deposit');
                   }}
                 >
@@ -151,7 +150,6 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 <Navbar.Link
                   isActive={formDataStore.mode === 'withdraw'}
                   onClick={() => {
-                    formDataStore.reset();
                     formDataStore.setMode('withdraw');
                   }}
                 >
@@ -164,7 +162,6 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 isDisabled={!matured}
                 isActive={formDataStore.mode === 'redeem'}
                 onClick={() => {
-                  formDataStore.reset();
                   formDataStore.setMode('redeem');
                 }}
               >

--- a/src/components/ModifyPositionModal.tsx
+++ b/src/components/ModifyPositionModal.tsx
@@ -320,7 +320,10 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
         </Text>
         <Input
           readOnly
-          value={formDataStore.formDataLoading ? ' ' : floor4(wadToDec(formDataStore.collateral))}
+          value={(formDataStore.formDataLoading)
+            ? ' '
+            : `${floor2(wadToDec(position.collateral))} → ${floor4(wadToDec(formDataStore.collateral))}`
+          }
           placeholder='0'
           type='string'
           label={`Collateral (before: ${floor2(wadToDec(position.collateral))} ${symbol})`}
@@ -331,7 +334,10 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
         />
         <Input
           readOnly
-          value={formDataStore.formDataLoading ? ' ' : floor4(wadToDec(formDataStore.debt))}
+          value={(formDataStore.formDataLoading)
+            ? ' '
+            : `${floor2(wadToDec(fiat.normalDebtToDebt(position.normalDebt, virtualRate)))} → ${floor4(wadToDec(formDataStore.debt))}`
+          }
           placeholder='0'
           type='string'
           label={`Debt (before: ${floor2(wadToDec(fiat.normalDebtToDebt(position.normalDebt, virtualRate)))} FIAT)`}
@@ -342,13 +348,17 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
         />
         <Input
           readOnly
-          value={
-            formDataStore.formDataLoading
-              ? ' '
-              : formDataStore.healthFactor.eq(ethers.constants.MaxUint256)
-              ? '∞'
-              : floor4(wadToDec(formDataStore.healthFactor))
-          }
+          value={(() => {
+            if (formDataStore.formDataLoading) return ' ';
+            let healthFactorBefore = fiat.computeHealthFactor(
+              position.collateral, position.normalDebt, virtualRate, liquidationPrice
+            );
+            healthFactorBefore = (healthFactorBefore.eq(ethers.constants.MaxUint256))
+              ? '∞' : floor4(wadToDec(healthFactorBefore));
+            const healthFactorAfter = (formDataStore.healthFactor.eq(ethers.constants.MaxUint256))
+              ? '∞' : floor4(wadToDec(formDataStore.healthFactor));
+            return `${healthFactorBefore} → ${healthFactorAfter}`;
+          })()}
           placeholder='0'
           type='string'
           label={

--- a/src/components/ModifyPositionModal.tsx
+++ b/src/components/ModifyPositionModal.tsx
@@ -142,6 +142,7 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 <Navbar.Link
                   isActive={formDataStore.mode === 'deposit'}
                   onClick={() => {
+                    formDataStore.resetCollateralAndDebtInputs(props.contextData.fiat, props.modifyPositionData);
                     formDataStore.setMode('deposit');
                   }}
                 >
@@ -150,6 +151,7 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 <Navbar.Link
                   isActive={formDataStore.mode === 'withdraw'}
                   onClick={() => {
+                    formDataStore.resetCollateralAndDebtInputs(props.contextData.fiat, props.modifyPositionData);
                     formDataStore.setMode('withdraw');
                   }}
                 >
@@ -162,6 +164,7 @@ const ModifyPositionModalBody = (props: ModifyPositionModalProps) => {
                 isDisabled={!matured}
                 isActive={formDataStore.mode === 'redeem'}
                 onClick={() => {
+                  formDataStore.resetCollateralAndDebtInputs(props.contextData.fiat, props.modifyPositionData);
                   formDataStore.setMode('redeem');
                 }}
               >

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -75,6 +75,7 @@ interface FormActions {
     modifyPositionData: any,
     selectedCollateralTypeId: string | null
   ) => void;
+  resetCollateralAndDebtInputs: (fiat: any, modifyPositionData: any) => void;
   reset: () => void;
 }
 
@@ -330,6 +331,13 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
 
       set(() => ({ formDataLoading: false }));
     }),
+
+    resetCollateralAndDebtInputs: (fiat, modifyPositionData) => {
+      const { deltaCollateral, deltaDebt, underlier } = initialState;
+      set(() => ({ deltaCollateral, deltaDebt, underlier }));
+      set(() => ({ formDataLoading: true }));
+      get().calculateNewPositionData(fiat, modifyPositionData, null);
+    },
 
     reset: () => {
       set(initialState);

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -226,12 +226,8 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
             const debt = deltaDebt;
             const healthFactor = fiat.computeHealthFactor(collateral, deltaNormalDebt, rate, liquidationPrice);
 
-            if (deltaDebt.gt(ethers.constants.Zero) && deltaDebt.lte(debtFloor) ) {
-              set(() => ({ formErrors: [
-                ...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`
-              ] }));
-            }
-            if (debt.gt(0) && healthFactor.lte(WAD)) console.error('Health factor has to be greater than 1.0');
+            if (deltaDebt.gt(ethers.constants.Zero) && deltaDebt.lte(debtFloor) ) set(() => ({ formErrors: [...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`] }));
+            if (debt.gt(0) && healthFactor.lte(WAD)) set(() => ({ formErrors: [...get().formErrors, 'Health factor has to be greater than 1.0'] }));
 
             set(() => ({ healthFactor, collateral, debt, deltaCollateral }));
           } else {
@@ -242,13 +238,8 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
             const normalDebt = fiat.debtToNormalDebt(debt, rate);
             const healthFactor = fiat.computeHealthFactor(collateral, normalDebt, rate, liquidationPrice);
 
-            if (debt.gt(ethers.constants.Zero) && debt.lte(collateralType.settings.codex.debtFloor) ) {
-              set(() => ({formErrors: [
-                ...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`
-              ] }));
-            }
-
-            if (debt.gt(0) && healthFactor.lte(WAD)) console.error('Health factor has to be greater than 1.0');
+            if (debt.gt(ethers.constants.Zero) && debt.lte(collateralType.settings.codex.debtFloor) ) set(() => ({formErrors: [...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`] }));
+            if (debt.gt(0) && healthFactor.lte(WAD)) set(() => ({ formErrors: [...get().formErrors, 'Health factor has to be greater than 1.0'] }));
 
             set(() => ({ healthFactor, collateral, debt, deltaCollateral }));
           }
@@ -262,8 +253,8 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
           }
           const deltaNormalDebt = fiat.debtToNormalDebt(deltaDebt, rate);
 
-          if (position.collateral.lt(deltaCollateral)) throw new Error('Insufficient collateral');
-          if (position.normalDebt.lt(deltaNormalDebt)) throw new Error('Insufficient debt');
+          if (position.collateral.lt(deltaCollateral)) set(() => ({ formErrors: [...get().formErrors, 'Insufficient collateral'] }));
+          if (position.normalDebt.lt(deltaNormalDebt)) set(() => ({ formErrors: [...get().formErrors, 'Insufficient debt'] }));
 
           const collateral = position.collateral.sub(deltaCollateral);
           let normalDebt = position.normalDebt.sub(deltaNormalDebt);
@@ -277,15 +268,15 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
           }
           const healthFactor = fiat.computeHealthFactor(collateral, normalDebt, rate, liquidationPrice);
           if (!(collateral.isZero() && normalDebt.isZero()) && healthFactor.lte(WAD))
-            throw new Error('Health factor has to be greater than 1.0');
+            set(() => ({ formErrors: [...get().formErrors, 'Health factor has to be greater than 1.0'] }));
 
           set(() => ({ healthFactor, underlier, collateral, debt }));
         } else if (mode === 'redeem') {
           const { deltaCollateral, deltaDebt } = get();
           const deltaNormalDebt = fiat.debtToNormalDebt(deltaDebt, rate);
 
-          if (position.collateral.lt(deltaCollateral)) throw new Error('Insufficient collateral');
-          if (position.normalDebt.lt(deltaNormalDebt)) throw new Error('Insufficient debt');
+          if (position.collateral.lt(deltaCollateral)) set(() => ({ formErrors: [...get().formErrors, 'Insufficient collateral'] }));
+          if (position.normalDebt.lt(deltaNormalDebt)) set(() => ({ formErrors: [...get().formErrors, 'Insufficient debt'] }));
 
           const collateral = position.collateral.sub(deltaCollateral);
           let normalDebt = position.normalDebt.sub(deltaNormalDebt);
@@ -299,7 +290,7 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
           }
           const healthFactor = fiat.computeHealthFactor(collateral, normalDebt, rate, liquidationPrice);
           if (!(collateral.isZero() && normalDebt.isZero()) && healthFactor.lte(WAD))
-            throw new Error('Health factor has to be greater than 1.0');
+            set(() => ({ formErrors: [...get().formErrors, 'Health factor has to be greater than 1.0'] }));
 
           set(() => ({ healthFactor, collateral, debt }));
         } else {

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -239,7 +239,7 @@ export const useModifyPositionFormDataStore = create<FormState & FormActions>()(
             const normalDebt = fiat.debtToNormalDebt(debt, rate);
             const healthFactor = fiat.computeHealthFactor(collateral, normalDebt, rate, liquidationPrice);
 
-            if (debt.gt(ethers.constants.Zero) && debt.lte(collateralType.settings.codex.debtFloor) ) set(() => ({formErrors: [...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`] }));
+            if (debt.gt(ethers.constants.Zero) && debt.lte(collateralType.settings.codex.debtFloor) ) set(() => ({ formErrors: [...get().formErrors, `Insufficient debt - debt must be above debt floor: ${wadToDec(debtFloor)}`] }));
             if (debt.gt(0) && healthFactor.lte(WAD)) set(() => ({ formErrors: [...get().formErrors, 'Health factor has to be greater than 1.0'] }));
 
             set(() => ({ healthFactor, collateral, debt, deltaCollateral }));


### PR DESCRIPTION
Adds multiple things...

* Display human readable errors for invalid form inputs
* Reset user inputs when switching between deposit and withdraw mode
* Refresh data after successful transactions
* Misc UI fixes (ex. remove scrollability of slider container, make modal slightly larger, different modal layouts for redeem mode vs deposit & withdraw modes)