### PR TITLE
Refactor reset state and refresh data

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,6 +93,53 @@ const Home: NextPage = () => {
     setFiatBalance(initialState.fiatBalance);
   }
 
+  const handleFinishedTransaction = () => {
+    // Soft reset after a transaction
+    setModifyPositionData(initialState.modifyPositionData);
+    setTransactionData(initialState.transactionData);
+    setSelectedPositionId(initialState.selectedPositionId);
+    setSelectedCollateralTypeId(initialState.selectedCollateralTypeId);
+    // Refetch data after a reset
+    handleFiatBalance();
+    handleCollateralTypesData();
+    handlePositionsData();
+  }
+
+  const handleFiatBalance = React.useCallback(async () => {
+    if (!contextData.fiat || !contextData.user) return;
+    const { fiat } = contextData.fiat.getContracts();
+    const fiatBalance = await fiat.balanceOf(contextData.user)
+    setFiatBalance(`${parseFloat(wadToDec(fiatBalance)).toFixed(2)} FIAT`)
+  }, [contextData]);
+
+  const handleCollateralTypesData = React.useCallback(async () => {
+    const fiat = contextData.fiat ? contextData.fiat : await FIAT.fromProvider(provider, null);
+    const collateralTypesData_ = await fiat.fetchCollateralTypesAndPrices([]);
+    const earnableRates = await userActions.getEarnableRate(fiat, collateralTypesData_);
+
+    setCollateralTypesData(collateralTypesData_
+      .filter((collateralType: any) => (collateralType.metadata != undefined))
+      .sort((a: any, b: any) => {
+        if (Number(a.properties.maturity) > Number(b.properties.maturity)) return -1;
+        if (Number(a.properties.maturity) < Number(b.properties.maturity)) return 1;
+        return 0;
+      })
+      .map((collateralType: any) => {
+        const earnableRate = earnableRates.find((item: any)  => item.vault === collateralType.properties.vault)
+        return {
+          ...collateralType,
+          earnableRate: earnableRate?.earnableRate
+        }
+      }));
+  }, [provider, contextData.fiat]);
+
+  const handlePositionsData = React.useCallback(async () => {
+    if (!contextData || !contextData.fiat) return;
+    const userData = await contextData.fiat.fetchUserData(contextData.user);
+    const positionsData = userData.flatMap((user) => user.positions);
+    setPositionsData(positionsData);
+  }, [contextData]);
+
   // Reset state if network or account changes
   React.useEffect(() => {
     if (!connector || setupListeners) return;
@@ -100,48 +147,24 @@ const Home: NextPage = () => {
     setSetupListeners(true);
   }, [setupListeners, connector, resetState]);
 
-  // Fetch CollateralTypes and block explorer data
+  // Fetch Collateral Types Data
   React.useEffect(() => {
     if (collateralTypesData.length !== 0) return;
+    handleCollateralTypesData();
+  }, [collateralTypesData.length, provider, handleCollateralTypesData])
 
-    (async function () {
-      const fiat = await FIAT.fromProvider(provider, null);
-      const collateralTypesData_ = await fiat.fetchCollateralTypesAndPrices([]);
-      const earnableRates = await userActions.getEarnableRate(fiat, collateralTypesData_);
-
-      setCollateralTypesData(collateralTypesData_
-        .filter((collateralType: any) => (collateralType.metadata != undefined))
-        .sort((a: any, b: any) => {
-          if (Number(a.properties.maturity) > Number(b.properties.maturity)) return -1;
-          if (Number(a.properties.maturity) < Number(b.properties.maturity)) return 1;
-          return 0;
-        })
-        .map((collateralType: any) => {
-          const earnableRate = earnableRates.find((item: any)  => item.vault === collateralType.properties.vault)
-          return {
-            ...collateralType,
-            earnableRate: earnableRate?.earnableRate
-          }
-        }));
-      setContextData((curContextData) => ({
-        ...curContextData,
-        explorerUrl: chain?.blockExplorers?.etherscan?.url || '',
-      }));
-    })();
-  }, [chain?.blockExplorers?.etherscan?.url, collateralTypesData.length, connector, provider]);
-
+  // Fetch block explorer data
   React.useEffect(() => {
-    if (connector) {
-      (async function () {
-        if (!contextData.fiat) return;
-        const { fiat } = contextData.fiat.getContracts();
-        const signer = (await connector.getSigner());
-        const user = await signer.getAddress();
-        const fiatBalance = await fiat.balanceOf(user)
-        setFiatBalance(`${parseFloat(wadToDec(fiatBalance)).toFixed(2)} FIAT`)
-      })();
-    }
-  }, [connector, contextData.fiat, address, chain])
+    if (!chain?.blockExplorers?.etherscan?.url) return;
+    setContextData((curContextData) => ({
+      ...curContextData,
+      explorerUrl: chain?.blockExplorers?.etherscan?.url || '',
+    }));
+  }, [chain?.blockExplorers?.etherscan?.url]);
+  
+  React.useEffect(() => {
+    handleFiatBalance();
+  }, [contextData.fiat, handleFiatBalance])
 
   // Fetch User data, Vault data, and set Fiat SDK in global state
   React.useEffect(() => {
@@ -261,7 +284,7 @@ const Home: NextPage = () => {
   }
 
   const createProxy = async (fiat: any, user: string) => {
-    // return await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    //await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
     const response = await sendStatefulTransaction(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
     addRecentTransaction({
       hash: response.transactionHash,
@@ -370,7 +393,7 @@ const Home: NextPage = () => {
           hash: resp.transactionHash,
           description: 'Modify Collateral and Debt',
         });
-        resetState();
+        handleFinishedTransaction();
         return resp;
       } else {
         const resp = await userActions.buyCollateralAndModifyDebt(
@@ -385,7 +408,7 @@ const Home: NextPage = () => {
           description: 'Buy Collateral And Modify Debt',
         });
 
-        resetState();
+        handleFinishedTransaction();
         return resp;
       }
     } catch (e) {
@@ -409,7 +432,7 @@ const Home: NextPage = () => {
           hash: resp.transactionHash,
           description: 'Modify Collateral and Debt',
         });
-        resetState();
+        handleFinishedTransaction();
         return resp;
       }
       else {
@@ -425,7 +448,7 @@ const Home: NextPage = () => {
           hash: resp.transactionHash,
           description: 'Sell Collateral and Modify Debt',
         });
-        resetState();
+        handleFinishedTransaction();
         return resp;
       }
     } catch (e) {
@@ -449,7 +472,7 @@ const Home: NextPage = () => {
           hash: resp.transactionHash,
           description: 'Modify Collateral and Debt',
         });
-        resetState();
+        handleFinishedTransaction();
         return resp;
       }
       else {
@@ -464,7 +487,7 @@ const Home: NextPage = () => {
           hash: resp.transactionHash,
           description: 'Redeem',
         });
-        resetState();
+        handleFinishedTransaction();
         return resp;
       }
     } catch (e) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -284,7 +284,7 @@ const Home: NextPage = () => {
   }
 
   const createProxy = async (fiat: any, user: string) => {
-    //await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
+    // return await dryRun(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
     const response = await sendStatefulTransaction(fiat, 'createProxy', fiat.getContracts().proxyRegistry, 'deployFor', user);
     addRecentTransaction({
       hash: response.transactionHash,


### PR DESCRIPTION
Main fix reverts a hard state refresh after a transaction and makse use of a softer reset in `handleFinishedTransaction`. This method also refreshes the fiat balance, collateralTypesData, and positionsData. I also refactored some of the async functions in the useEffects into useCallbacks to be reused by `handleFinishedTransaction`

Other Optimizations:
- Getting fiat balance makes better use of contextData
- Getting Collateral Types data will use the `contextData.fiat` instead of initializing from provider each time.
- Separated getting collateral types from setting block url in the context